### PR TITLE
Added the ability to add a pregenerated 2FA code

### DIFF
--- a/recnetlogin/base_client.py
+++ b/recnetlogin/base_client.py
@@ -7,6 +7,7 @@ class BaseClient():
         username: str, 
         password: str,
         prompt_2fa: bool = False,
+        given_2fa: str = "",
         session: aiohttp.ClientSession or httpx.Client = None,
         **kwargs
     ) -> None:
@@ -20,3 +21,5 @@ class BaseClient():
         self.decoded = {}
         # Whether or not to prompt for 2fa code
         self.prompt_2fa = prompt_2fa
+        # 2FA token
+        self.given_2fa = given_2fa

--- a/recnetlogin/sync_client.py
+++ b/recnetlogin/sync_client.py
@@ -33,7 +33,10 @@ class RecNetLogin(BaseClient):
             return
         
     def __login_2fa(self) -> None:
-        twofa_code = prompt_2fa()
+        if self.given_2fa:
+            twofa_code = self.given_2fa
+        else:
+            twofa_code = prompt_2fa()
 
         resp = self.__session.get(ApiInfo.TWOFA_URL)
         html = resp.content


### PR DESCRIPTION
I was able to use the 2FA Secret from my account to generate the current 2FA code, so I don't need to enter it myself.

I haven't vetted this when it comes to efficiency or security or rate limiting, but it works well enough for my own project, and I thought I should contribute.

You should probably test it before merging.